### PR TITLE
Utilize Dependency Injection for ContactsRepository

### DIFF
--- a/app/src/main/java/com/bnyro/contacts/App.kt
+++ b/app/src/main/java/com/bnyro/contacts/App.kt
@@ -2,12 +2,21 @@ package com.bnyro.contacts
 
 import android.app.Application
 import com.bnyro.contacts.db.DatabaseHolder
+import com.bnyro.contacts.util.DeviceContactsRepository
+import com.bnyro.contacts.util.LocalContactsRepository
 import com.bnyro.contacts.util.NotificationHelper
 import com.bnyro.contacts.util.Preferences
 import com.bnyro.contacts.util.ShortcutHelper
 import com.bnyro.contacts.workers.BackupWorker
 
 class App : Application() {
+    val deviceContactsRepository by lazy {
+        DeviceContactsRepository(this)
+    }
+    val localContactsRepository by lazy {
+        LocalContactsRepository(this)
+    }
+
     override fun onCreate() {
         super.onCreate()
 

--- a/app/src/main/java/com/bnyro/contacts/enums/ContactsSource.kt
+++ b/app/src/main/java/com/bnyro/contacts/enums/ContactsSource.kt
@@ -1,0 +1,5 @@
+package com.bnyro.contacts.enums
+
+enum class ContactsSource {
+    DEVICE, LOCAL
+}

--- a/app/src/main/java/com/bnyro/contacts/obj/NavBarItem.kt
+++ b/app/src/main/java/com/bnyro/contacts/obj/NavBarItem.kt
@@ -5,5 +5,5 @@ import androidx.compose.ui.graphics.vector.ImageVector
 data class NavBarItem(
     val label: String,
     val icon: ImageVector,
-    val onClick: () -> Unit
+    val onClick: () -> Unit = {}
 )

--- a/app/src/main/java/com/bnyro/contacts/ui/activities/BaseActivity.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/activities/BaseActivity.kt
@@ -1,24 +1,23 @@
 package com.bnyro.contacts.ui.activities
 
 import android.os.Bundle
-import android.os.PersistableBundle
 import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
 import com.bnyro.contacts.ui.models.ContactsModel
 import com.bnyro.contacts.ui.models.ThemeModel
 
-abstract class BaseActivity: ComponentActivity() {
+abstract class BaseActivity : ComponentActivity() {
     lateinit var themeModel: ThemeModel
-    lateinit var contactsModel: ContactsModel
+    val contactsModel by viewModels<ContactsModel> {
+        ContactsModel.Factory
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val viewModelProvider = ViewModelProvider(this)
         themeModel = viewModelProvider.get()
-        contactsModel = viewModelProvider.get()
-
-        contactsModel.init(this)
     }
 }

--- a/app/src/main/java/com/bnyro/contacts/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/activities/MainActivity.kt
@@ -32,7 +32,7 @@ class MainActivity : BaseActivity() {
 
         setContent {
             ConnectYouTheme(themeModel.themeMode) {
-                MainAppContent(contactsModel, smsModel!!)
+                MainAppContent(smsModel!!)
                 getInsertOrEditNumber()?.let {
                     AddToContactDialog(it)
                 }

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactEditor.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactEditor.kt
@@ -57,7 +57,7 @@ import com.bnyro.contacts.ui.components.editor.DatePickerEditor
 import com.bnyro.contacts.ui.components.editor.TextFieldEditor
 import com.bnyro.contacts.ui.models.ContactsModel
 import com.bnyro.contacts.util.ContactsHelper
-import com.bnyro.contacts.util.DeviceContactsHelper
+import com.bnyro.contacts.util.DeviceContactsRepository
 import com.bnyro.contacts.util.ImageHelper
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -69,7 +69,7 @@ fun ContactEditor(
     onSave: (contact: ContactData) -> Unit
 ) {
     val context = LocalContext.current
-    val contactsModel: ContactsModel = viewModel()
+    val contactsModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
 
     fun List<ValueWithType>?.fillIfEmpty(): List<ValueWithType> {
         return if (this.isNullOrEmpty()) {
@@ -147,8 +147,8 @@ fun ContactEditor(
 
     var selectedAccount by remember {
         mutableStateOf(
-            (contact?.accountType ?: DeviceContactsHelper.ANDROID_ACCOUNT_TYPE) to
-                    (contact?.accountName ?: DeviceContactsHelper.ANDROID_CONTACTS_NAME)
+            (contact?.accountType ?: DeviceContactsRepository.ANDROID_ACCOUNT_TYPE) to
+                (contact?.accountName ?: DeviceContactsRepository.ANDROID_CONTACTS_NAME)
         )
     }
 

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactItem.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactItem.kt
@@ -52,7 +52,7 @@ fun ContactItem(
     onLongPress: () -> Unit
 ) {
     val shape = RoundedCornerShape(20.dp)
-    val viewModel: ContactsModel = viewModel()
+    val viewModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
     val themeModel: ThemeModel = viewModel()
 
     var showContactScreen by remember {

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ShareDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ShareDialog.kt
@@ -20,7 +20,7 @@ fun ShareDialog(
     contact: ContactData,
     onDismissRequest: () -> Unit
 ) {
-    val contactsModel: ContactsModel = viewModel()
+    val contactsModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
     val context = LocalContext.current
 
     val shareName = remember { mutableStateOf(true) }

--- a/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/AddToContactDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/AddToContactDialog.kt
@@ -32,7 +32,7 @@ fun AddToContactDialog(
     newNumber: String
 ) {
     val context = LocalContext.current
-    val contactsModel: ContactsModel = viewModel()
+    val contactsModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
 
     var showDialog by remember {
         mutableStateOf(true)
@@ -85,7 +85,7 @@ fun AddToContactDialog(
                         modifier = Modifier.height(400.dp)
                     ) {
                         items(
-                            contactsModel.contacts.orEmpty()
+                            contactsModel.contacts
                                 .filter {
                                     it.displayName.orEmpty().lowercase().contains(
                                         searchQuery.lowercase()

--- a/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/GroupsDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/GroupsDialog.kt
@@ -39,7 +39,7 @@ fun GroupsDialog(
     participatingGroups: List<ContactsGroup>,
     onContactGroupsChanges: (participatingGroups: List<ContactsGroup>) -> Unit
 ) {
-    val contactsModel: ContactsModel = viewModel()
+    val contactsModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
@@ -105,7 +105,7 @@ fun GroupsDialog(
         ) {
             scope.launch {
                 withContext(Dispatchers.IO) {
-                    contactsModel.contactsHelper?.deleteGroup(it)
+                    contactsModel.contactsRepository.deleteGroup(it)
                 }
                 contactGroups = contactGroups - it
                 if (participatingGroups.contains(it)) {
@@ -127,7 +127,7 @@ fun GroupsDialog(
                     if (title.isNotBlank() && contactGroups.none { it.title == title }) {
                         scope.launch {
                             val group = withContext(Dispatchers.IO) {
-                                contactsModel.contactsHelper?.createGroup(title)
+                                contactsModel.contactsRepository.createGroup(title)
                             }
                             group?.let { contactGroups = contactGroups + it }
                             showCreateGroup = false

--- a/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/SimImportDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/SimImportDialog.kt
@@ -44,7 +44,7 @@ fun SimImportDialog(
         mutableStateOf(true)
     }
     val context = LocalContext.current
-    val contactsModel: ContactsModel = viewModel()
+    val contactsModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
@@ -98,7 +98,9 @@ fun SimImportDialog(
                                 onCheckedChange = {
                                     if (it) {
                                         selectedContacts.add(contact)
-                                    } else selectedContacts.remove(contact)
+                                    } else {
+                                        selectedContacts.remove(contact)
+                                    }
                                 }
                             )
                             Spacer(modifier = Modifier.width(10.dp))

--- a/app/src/main/java/com/bnyro/contacts/util/ContactsHelper.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/ContactsHelper.kt
@@ -2,109 +2,90 @@ package com.bnyro.contacts.util
 
 import android.provider.ContactsContract
 import com.bnyro.contacts.R
-import com.bnyro.contacts.obj.ContactData
-import com.bnyro.contacts.obj.ContactsGroup
 import com.bnyro.contacts.obj.TranslatedType
 
-abstract class ContactsHelper {
-    abstract val label: String
+object ContactsHelper {
 
-    abstract suspend fun createContact(contact: ContactData)
+    val emailTypes = listOf(
+        TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_HOME, R.string.home),
+        TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_WORK, R.string.work),
+        TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_MOBILE, R.string.mobile),
+        TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_CUSTOM, R.string.custom),
+        TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_OTHER, R.string.other)
+    )
 
-    abstract suspend fun updateContact(contact: ContactData)
+    val phoneNumberTypes = listOf(
+        TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_HOME, R.string.home),
+        TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE, R.string.mobile),
+        TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_WORK, R.string.work),
+        TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_CAR, R.string.car),
+        TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_FAX_HOME, R.string.fax_home),
+        TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_FAX_WORK, R.string.fax_work),
+        TranslatedType(
+            ContactsContract.CommonDataKinds.Phone.TYPE_ASSISTANT,
+            R.string.assistant
+        ),
+        TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM, R.string.custom),
+        TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_OTHER, R.string.other)
+    )
 
-    abstract suspend fun deleteContacts(contacts: List<ContactData>)
-
-    abstract suspend fun getContactList(): List<ContactData>
-
-    abstract suspend fun loadAdvancedData(contact: ContactData): ContactData
-
-    abstract fun isAutoBackupEnabled(): Boolean
-
-    abstract suspend fun createGroup(groupName: String): ContactsGroup?
-
-    abstract suspend fun renameGroup(group: ContactsGroup, newName: String)
-
-    abstract suspend fun deleteGroup(group: ContactsGroup)
-
-    companion object {
-        val emailTypes = listOf(
-            TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_HOME, R.string.home),
-            TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_WORK, R.string.work),
-            TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_MOBILE, R.string.mobile),
-            TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_CUSTOM, R.string.custom),
-            TranslatedType(ContactsContract.CommonDataKinds.Email.TYPE_OTHER, R.string.other)
+    val addressTypes = listOf(
+        TranslatedType(
+            ContactsContract.CommonDataKinds.StructuredPostal.TYPE_HOME,
+            R.string.home
+        ),
+        TranslatedType(
+            ContactsContract.CommonDataKinds.StructuredPostal.TYPE_WORK,
+            R.string.work
+        ),
+        TranslatedType(
+            ContactsContract.CommonDataKinds.StructuredPostal.TYPE_CUSTOM,
+            R.string.custom
+        ),
+        TranslatedType(
+            ContactsContract.CommonDataKinds.StructuredPostal.TYPE_OTHER,
+            R.string.other
         )
+    )
 
-        val phoneNumberTypes = listOf(
-            TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_HOME, R.string.home),
-            TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE, R.string.mobile),
-            TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_WORK, R.string.work),
-            TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_CAR, R.string.car),
-            TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_FAX_HOME, R.string.fax_home),
-            TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_FAX_WORK, R.string.fax_work),
-            TranslatedType(
-                ContactsContract.CommonDataKinds.Phone.TYPE_ASSISTANT,
-                R.string.assistant
-            ),
-            TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM, R.string.custom),
-            TranslatedType(ContactsContract.CommonDataKinds.Phone.TYPE_OTHER, R.string.other)
-        )
+    val eventTypes = listOf(
+        TranslatedType(ContactsContract.CommonDataKinds.Event.TYPE_BIRTHDAY, R.string.birthday),
+        TranslatedType(
+            ContactsContract.CommonDataKinds.Event.TYPE_ANNIVERSARY,
+            R.string.anniversary
+        ),
+        TranslatedType(ContactsContract.CommonDataKinds.Event.TYPE_CUSTOM, R.string.custom),
+        TranslatedType(ContactsContract.CommonDataKinds.Event.TYPE_OTHER, R.string.other)
+    )
 
-        val addressTypes = listOf(
-            TranslatedType(
-                ContactsContract.CommonDataKinds.StructuredPostal.TYPE_HOME,
-                R.string.home
-            ),
-            TranslatedType(
-                ContactsContract.CommonDataKinds.StructuredPostal.TYPE_WORK,
-                R.string.work
-            ),
-            TranslatedType(
-                ContactsContract.CommonDataKinds.StructuredPostal.TYPE_CUSTOM,
-                R.string.custom
-            ),
-            TranslatedType(
-                ContactsContract.CommonDataKinds.StructuredPostal.TYPE_OTHER,
-                R.string.other
-            )
-        )
+    val websiteTypes = listOf(
+        TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_HOME, R.string.home),
+        TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_WORK, R.string.work),
+        TranslatedType(
+            ContactsContract.CommonDataKinds.Website.TYPE_HOMEPAGE,
+            R.string.homepage
+        ),
+        TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_BLOG, R.string.blog),
+        TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_FTP, R.string.ftp),
+        TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_CUSTOM, R.string.custom),
+        TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_OTHER, R.string.other)
+    )
 
-        val eventTypes = listOf(
-            TranslatedType(ContactsContract.CommonDataKinds.Event.TYPE_BIRTHDAY, R.string.birthday),
-            TranslatedType(
-                ContactsContract.CommonDataKinds.Event.TYPE_ANNIVERSARY,
-                R.string.anniversary
-            ),
-            TranslatedType(ContactsContract.CommonDataKinds.Event.TYPE_CUSTOM, R.string.custom),
-            TranslatedType(ContactsContract.CommonDataKinds.Event.TYPE_OTHER, R.string.other)
-        )
+    fun splitFullName(displayName: String?): Pair<String, String> {
+        val displayNameParts = displayName.orEmpty().split(" ")
+        return when {
+            displayNameParts.size >= 2 -> {
+                displayNameParts.subList(0, displayNameParts.size - 1).joinToString(
+                    " "
+                ) to displayNameParts.last()
+            }
 
-        val websiteTypes = listOf(
-            TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_HOME, R.string.home),
-            TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_WORK, R.string.work),
-            TranslatedType(
-                ContactsContract.CommonDataKinds.Website.TYPE_HOMEPAGE,
-                R.string.homepage
-            ),
-            TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_BLOG, R.string.blog),
-            TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_FTP, R.string.ftp),
-            TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_CUSTOM, R.string.custom),
-            TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_OTHER, R.string.other)
-        )
+            displayNameParts.size == 1 -> {
+                displayNameParts.first() to ""
+            }
 
-        fun splitFullName(displayName: String?): Pair<String, String> {
-            val displayNameParts = displayName.orEmpty().split(" ")
-            return when {
-                displayNameParts.size >= 2 -> {
-                    displayNameParts.subList(0, displayNameParts.size - 1).joinToString(
-                        " "
-                    ) to displayNameParts.last()
-                }
-                displayNameParts.size == 1 -> {
-                    displayNameParts.first() to ""
-                }
-                else -> { "" to "" }
+            else -> {
+                "" to ""
             }
         }
     }

--- a/app/src/main/java/com/bnyro/contacts/util/ContactsRepository.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/ContactsRepository.kt
@@ -1,0 +1,18 @@
+package com.bnyro.contacts.util
+
+import com.bnyro.contacts.obj.ContactData
+import com.bnyro.contacts.obj.ContactsGroup
+
+interface ContactsRepository {
+    val label: String
+
+    suspend fun createContact(contact: ContactData)
+    suspend fun updateContact(contact: ContactData)
+    suspend fun deleteContacts(contacts: List<ContactData>)
+    suspend fun getContactList(): List<ContactData>
+    suspend fun loadAdvancedData(contact: ContactData): ContactData
+    fun isAutoBackupEnabled(): Boolean
+    suspend fun createGroup(groupName: String): ContactsGroup?
+    suspend fun renameGroup(group: ContactsGroup, newName: String)
+    suspend fun deleteGroup(group: ContactsGroup)
+}

--- a/app/src/main/java/com/bnyro/contacts/util/DeviceContactsRepository.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/DeviceContactsRepository.kt
@@ -36,7 +36,7 @@ import com.bnyro.contacts.obj.ContactData
 import com.bnyro.contacts.obj.ContactsGroup
 import com.bnyro.contacts.obj.ValueWithType
 
-class DeviceContactsHelper(private val context: Context) : ContactsHelper() {
+class DeviceContactsRepository(private val context: Context) : ContactsRepository {
     override val label: String = context.getString(R.string.device)
 
     private val contentResolver = context.contentResolver
@@ -85,7 +85,7 @@ class DeviceContactsHelper(private val context: Context) : ContactsHelper() {
 
                 // try parsing the display name to a proper name
                 if (firstName.notAName() || surName.notAName()) {
-                    val nameParts = splitFullName(displayName)
+                    val nameParts = ContactsHelper.splitFullName(displayName)
                     firstName = nameParts.first
                     surName = nameParts.second
                 }

--- a/app/src/main/java/com/bnyro/contacts/util/LocalContactsRepository.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/LocalContactsRepository.kt
@@ -15,7 +15,7 @@ import com.bnyro.contacts.obj.ContactsGroup
 import com.bnyro.contacts.obj.ValueWithType
 import java.io.File
 
-class LocalContactsHelper(context: Context) : ContactsHelper() {
+class LocalContactsRepository(context: Context) : ContactsRepository {
     override val label: String = context.getString(R.string.local)
 
     private val picturesDir = File(context.filesDir, "images").also {

--- a/app/src/main/java/com/bnyro/contacts/workers/BackupWorker.kt
+++ b/app/src/main/java/com/bnyro/contacts/workers/BackupWorker.kt
@@ -6,10 +6,9 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.bnyro.contacts.App
 import com.bnyro.contacts.enums.BackupType
 import com.bnyro.contacts.util.BackupHelper
-import com.bnyro.contacts.util.DeviceContactsHelper
-import com.bnyro.contacts.util.LocalContactsHelper
 import com.bnyro.contacts.util.Preferences
 import java.util.concurrent.TimeUnit
 
@@ -18,13 +17,15 @@ class BackupWorker(
     params: WorkerParameters
 ) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
+        val app = applicationContext as App
         val contactHelpers = when (Preferences.getBackupType()) {
             BackupType.BOTH -> listOf(
-                DeviceContactsHelper(applicationContext),
-                LocalContactsHelper(applicationContext)
+                app.deviceContactsRepository,
+                app.localContactsRepository
             )
-            BackupType.DEVICE -> listOf(DeviceContactsHelper(applicationContext))
-            BackupType.LOCAL -> listOf(LocalContactsHelper(applicationContext))
+
+            BackupType.DEVICE -> listOf(app.deviceContactsRepository)
+            BackupType.LOCAL -> listOf(app.localContactsRepository)
             else -> return Result.success()
         }
         contactHelpers.forEach {


### PR DESCRIPTION
I know you didn't expect this, but I wanted to utilize some dependency injection.

- Moved the code from `ContactHelper` into a `ContactRepository`
- Created a singleton instance of each repository inside the Application class
- Created `ContatsSource` enum to switch between `Device` and `Local` Repositories

There's no clear performance benefit from doing this, but the overall code looks cleaner and easy to understand.
And since the repository is a singleton now, we can do some caching to improve performance in the future.

PS: I had to do all the changes in one commit because the code was too intermingled.

Whether or not you use the changes is up to you. I just wanted to give you a heads up.