### PR TITLE
Fast and smooth tab switching

### DIFF
--- a/app/src/main/java/com/bnyro/contacts/ui/activities/BaseActivity.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/activities/BaseActivity.kt
@@ -1,5 +1,6 @@
 package com.bnyro.contacts.ui.activities
 
+import android.Manifest
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
@@ -7,6 +8,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
 import com.bnyro.contacts.ui.models.ContactsModel
 import com.bnyro.contacts.ui.models.ThemeModel
+import com.bnyro.contacts.util.PermissionHelper
 
 abstract class BaseActivity : ComponentActivity() {
     lateinit var themeModel: ThemeModel
@@ -16,7 +18,13 @@ abstract class BaseActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        PermissionHelper.checkPermissions(
+            this,
+            arrayOf(
+                Manifest.permission.WRITE_CONTACTS,
+                Manifest.permission.READ_CONTACTS
+            )
+        )
         val viewModelProvider = ViewModelProvider(this)
         themeModel = viewModelProvider.get()
     }

--- a/app/src/main/java/com/bnyro/contacts/ui/activities/PickContactActivity.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/activities/PickContactActivity.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.ContentUris
 import android.content.Intent
 import android.os.Bundle
-import android.os.PersistableBundle
 import android.provider.ContactsContract
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
@@ -37,8 +36,6 @@ class PickContactActivity : BaseActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        contactsModel.loadContacts(this)
 
         setContent {
             ConnectYouTheme(themeModel.themeMode) {

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactsPage.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactsPage.kt
@@ -6,7 +6,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -23,7 +21,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CopyAll
 import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.ImportContacts
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MoveToInbox
 import androidx.compose.material.icons.filled.Sort
@@ -36,7 +33,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -65,6 +61,7 @@ import com.bnyro.contacts.ui.components.dialogs.FilterDialog
 import com.bnyro.contacts.ui.components.dialogs.SimImportDialog
 import com.bnyro.contacts.ui.components.modifier.scrollbar
 import com.bnyro.contacts.ui.models.ContactsModel
+import com.bnyro.contacts.ui.models.state.ContactListState
 import com.bnyro.contacts.ui.screens.AboutScreen
 import com.bnyro.contacts.ui.screens.EditorScreen
 import com.bnyro.contacts.ui.screens.SettingsScreen
@@ -72,7 +69,6 @@ import com.bnyro.contacts.ui.screens.SingleContactScreen
 import com.bnyro.contacts.util.BackupHelper
 import com.bnyro.contacts.util.PermissionHelper
 import com.bnyro.contacts.util.Preferences
-import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -130,10 +126,6 @@ fun ContactsPage(
         targetValue = bottomBarOffsetHeight,
         label = "fab padding"
     )
-
-    LaunchedEffect(viewModel.contactsSource) {
-        viewModel.loadContacts(context)
-    }
 
     Box(
         modifier = Modifier.fillMaxSize()
@@ -275,90 +267,98 @@ fun ContactsPage(
                 Manifest.permission.READ_CONTACTS
             )
 
-            if (viewModel.isLoading) {
-                LaunchedEffect(Unit) {
-                    if (hasPerms() || viewModel.contactsSource != ContactsSource.DEVICE) return@LaunchedEffect
-                    while (!hasPerms()) {
-                        delay(100)
-                    }
-                    viewModel.loadContacts(context)
-                }
-                Box(
-                    modifier = Modifier.fillMaxSize()
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.Center)
-                    )
-                }
-            } else if (viewModel.contacts.isEmpty()) {
-                NothingHere()
-            } else {
-                val state = rememberLazyListState()
-                LazyColumn(
-                    state = state,
-                    modifier = Modifier
-                        .padding(end = 5.dp)
-                        .scrollbar(state, false)
-                        .let { modifier ->
-                            scrollConnection?.let { modifier.nestedScroll(it) } ?: modifier
+            when (val contactState = viewModel.contactListState) {
+                ContactListState.Loading -> {
+                    /*
+                    LaunchedEffect(Unit) {
+                        if (hasPerms() || viewModel.contactsSource != ContactsSource.DEVICE) return@LaunchedEffect
+                        while (!hasPerms()) {
+                            delay(100)
                         }
-                ) {
-                    val query = searchQuery.value.text.lowercase()
-                    val contactGroups = viewModel.contacts.asSequence().filter {
-                        it.displayName.orEmpty().lowercase().contains(query) ||
-                            it.numbers.any { number -> number.value.contains(query) }
-                    }.filter {
-                        !filterOptions.hiddenAccountNames.contains(it.accountName)
-                    }.filter {
-                        if (filterOptions.visibleGroups.isEmpty()) {
-                            true
-                        } else {
-                            filterOptions.visibleGroups.any { group ->
-                                it.groups.contains(group)
+                        viewModel.loadContacts(context)
+                    }
+                     */
+                    Box(
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    }
+                }
+
+                ContactListState.Empty, ContactListState.Error -> {
+                    NothingHere()
+                }
+
+                is ContactListState.Success -> {
+                    val state = rememberLazyListState()
+                    LazyColumn(
+                        state = state,
+                        modifier = Modifier
+                            .padding(end = 5.dp)
+                            .scrollbar(state, false)
+                            .let { modifier ->
+                                scrollConnection?.let { modifier.nestedScroll(it) } ?: modifier
+                            }
+                    ) {
+                        val query = searchQuery.value.text.lowercase()
+                        val contactGroups = contactState.contacts.asSequence().filter {
+                            it.displayName.orEmpty().lowercase().contains(query) ||
+                                it.numbers.any { number -> number.value.contains(query) }
+                        }.filter {
+                            !filterOptions.hiddenAccountNames.contains(it.accountName)
+                        }.filter {
+                            if (filterOptions.visibleGroups.isEmpty()) {
+                                true
+                            } else {
+                                filterOptions.visibleGroups.any { group ->
+                                    it.groups.contains(group)
+                                }
+                            }
+                        }.sortedBy {
+                            when (filterOptions.sortOder) {
+                                SortOrder.FIRSTNAME -> it.displayName
+                                SortOrder.LASTNAME -> it.alternativeName
+                            }
+                        }.groupBy {
+                            when (filterOptions.sortOder) {
+                                SortOrder.FIRSTNAME -> it.displayName
+                                SortOrder.LASTNAME -> it.alternativeName
+                            }?.firstOrNull()?.uppercase()
+                        }
+
+                        contactGroups.forEach { (firstLetter, groupedContacts) ->
+                            stickyHeader {
+                                CharacterHeader(firstLetter.orEmpty())
+                            }
+                            items(groupedContacts) {
+                                ContactItem(
+                                    contact = it,
+                                    sortOrder = filterOptions.sortOder,
+                                    selected = selectedContacts.contains(it),
+                                    onSinglePress = {
+                                        if (selectedContacts.isEmpty()) {
+                                            false
+                                        } else {
+                                            if (selectedContacts.contains(it)) {
+                                                selectedContacts.remove(it)
+                                            } else {
+                                                selectedContacts.add(it)
+                                            }
+                                            true
+                                        }
+                                    },
+                                    onLongPress = {
+                                        if (!selectedContacts.contains(it)) selectedContacts.add(it)
+                                    }
+                                )
                             }
                         }
-                    }.sortedBy {
-                        when (filterOptions.sortOder) {
-                            SortOrder.FIRSTNAME -> it.displayName
-                            SortOrder.LASTNAME -> it.alternativeName
-                        }
-                    }.groupBy {
-                        when (filterOptions.sortOder) {
-                            SortOrder.FIRSTNAME -> it.displayName
-                            SortOrder.LASTNAME -> it.alternativeName
-                        }?.firstOrNull()?.uppercase()
-                    }
 
-                    contactGroups.forEach { (firstLetter, groupedContacts) ->
-                        stickyHeader {
-                            CharacterHeader(firstLetter.orEmpty())
+                        item {
+                            Spacer(modifier = Modifier.height(10.dp))
                         }
-                        items(groupedContacts) {
-                            ContactItem(
-                                contact = it,
-                                sortOrder = filterOptions.sortOder,
-                                selected = selectedContacts.contains(it),
-                                onSinglePress = {
-                                    if (selectedContacts.isEmpty()) {
-                                        false
-                                    } else {
-                                        if (selectedContacts.contains(it)) {
-                                            selectedContacts.remove(it)
-                                        } else {
-                                            selectedContacts.add(it)
-                                        }
-                                        true
-                                    }
-                                },
-                                onLongPress = {
-                                    if (!selectedContacts.contains(it)) selectedContacts.add(it)
-                                }
-                            )
-                        }
-                    }
-
-                    item {
-                        Spacer(modifier = Modifier.height(10.dp))
                     }
                 }
             }

--- a/app/src/main/java/com/bnyro/contacts/ui/models/ContactsModel.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/models/ContactsModel.kt
@@ -121,28 +121,28 @@ class ContactsModel(
     }
 
     fun deleteContacts(contactsToDelete: List<ContactData>) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             contactsRepository.deleteContacts(contactsToDelete)
             contacts = contacts.minus(contactsToDelete.toSet())
         }
     }
 
     fun createContact(context: Context, contact: ContactData) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             contactsRepository.createContact(contact)
             loadContacts(context)
         }
     }
 
     fun updateContact(context: Context, contact: ContactData) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             contactsRepository.updateContact(contact)
             loadContacts(context)
         }
     }
 
     fun copyContacts(context: Context, contacts: List<ContactData>) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             contacts.forEach { contact ->
                 val fullContact = loadAdvancedContactData(contact)
                 val otherHelper = when (contactsRepository) {

--- a/app/src/main/java/com/bnyro/contacts/ui/models/ContactsModel.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/models/ContactsModel.kt
@@ -70,12 +70,6 @@ class ContactsModel(
             }
         }
 
-    val contactListState: ContactListState
-        get() = when (contactsSource) {
-            ContactsSource.LOCAL -> localContacts
-            ContactsSource.DEVICE -> deviceContacts
-        }
-
     init {
         loadContacts(context)
     }

--- a/app/src/main/java/com/bnyro/contacts/ui/models/state/ContactListState.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/models/state/ContactListState.kt
@@ -1,0 +1,10 @@
+package com.bnyro.contacts.ui.models.state
+
+import com.bnyro.contacts.obj.ContactData
+
+sealed interface ContactListState {
+    object Loading : ContactListState
+    data class Success(var contacts: List<ContactData>) : ContactListState
+    object Error : ContactListState
+    object Empty : ContactListState
+}

--- a/app/src/main/java/com/bnyro/contacts/ui/screens/MainAppContent.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/screens/MainAppContent.kt
@@ -18,12 +18,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -43,16 +41,12 @@ import com.bnyro.contacts.ui.models.SmsModel
 import com.bnyro.contacts.ui.models.ThemeModel
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun MainAppContent(smsModel: SmsModel) {
     val themeModel: ThemeModel = viewModel()
     val contactsModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
-    val scope = rememberCoroutineScope()
 
     val bottomBarHeight = 80.dp
     val bottomBarHeightPx = with(LocalDensity.current) { bottomBarHeight.roundToPx().toFloat() }
@@ -64,19 +58,6 @@ fun MainAppContent(smsModel: SmsModel) {
                 val newOffset = bottomBarOffsetHeightPx.value + available.y
                 bottomBarOffsetHeightPx.value = newOffset.coerceIn(-bottomBarHeightPx, 0f)
                 return Offset.Zero
-            }
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        contactsModel.initialContactId ?: return@LaunchedEffect
-        contactsModel.contacts.firstOrNull {
-            it.contactId == contactsModel.initialContactId
-        }?.let {
-            scope.launch {
-                withContext(Dispatchers.IO) {
-                    contactsModel.initialContactData = contactsModel.loadAdvancedContactData(it)
-                }
             }
         }
     }

--- a/app/src/main/java/com/bnyro/contacts/ui/screens/MainAppContent.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/screens/MainAppContent.kt
@@ -1,6 +1,7 @@
 package com.bnyro.contacts.ui.screens
 
 import android.annotation.SuppressLint
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -28,7 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
@@ -41,7 +41,6 @@ import com.bnyro.contacts.ui.components.ContactsPage
 import com.bnyro.contacts.ui.models.ContactsModel
 import com.bnyro.contacts.ui.models.SmsModel
 import com.bnyro.contacts.ui.models.ThemeModel
-import com.bnyro.contacts.util.Preferences
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
@@ -51,7 +50,6 @@ import kotlinx.coroutines.withContext
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun MainAppContent(smsModel: SmsModel) {
-    val context = LocalContext.current
     val themeModel: ThemeModel = viewModel()
     val contactsModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
     val scope = rememberCoroutineScope()
@@ -59,15 +57,6 @@ fun MainAppContent(smsModel: SmsModel) {
     val bottomBarHeight = 80.dp
     val bottomBarHeightPx = with(LocalDensity.current) { bottomBarHeight.roundToPx().toFloat() }
     val bottomBarOffsetHeightPx = remember { mutableStateOf(0f) }
-
-    var selectedTab by remember {
-        val tab = if (smsModel.initialAddressAndBody != null) {
-            2
-        } else {
-            Preferences.getInt(Preferences.homeTabKey, 0)
-        }
-        mutableIntStateOf(tab)
-    }
 
     val nestedScrollConnection = remember {
         object : NestedScrollConnection {
@@ -79,7 +68,7 @@ fun MainAppContent(smsModel: SmsModel) {
         }
     }
 
-    LaunchedEffect(contactsModel.contactListState) {
+    LaunchedEffect(Unit) {
         contactsModel.initialContactId ?: return@LaunchedEffect
         contactsModel.contacts.firstOrNull {
             it.contactId == contactsModel.initialContactId
@@ -111,6 +100,16 @@ fun MainAppContent(smsModel: SmsModel) {
         )
     )
 
+    var currentPage by remember {
+        mutableIntStateOf(
+            if (smsModel.initialAddressAndBody != null) {
+                2
+            } else {
+                contactsModel.contactsSource.ordinal
+            }
+        )
+    }
+
     Scaffold(
         bottomBar = {
             NavigationBar(
@@ -127,12 +126,10 @@ fun MainAppContent(smsModel: SmsModel) {
             ) {
                 navItems.forEachIndexed { index, navItem ->
                     NavigationBarItem(
-                        selected = index == selectedTab,
+                        selected = (index == currentPage),
                         onClick = {
-                            if (contactsModel.contactsSource.ordinal == index) return@NavigationBarItem
-                            if (index < 2) contactsModel.contactsSource = ContactsSource.values()[index]
-                            navItem.onClick()
-                            selectedTab = index
+                            navItem.onClick.invoke()
+                            currentPage = index
                         },
                         icon = {
                             Icon(navItem.icon, null)
@@ -153,15 +150,18 @@ fun MainAppContent(smsModel: SmsModel) {
                 },
             color = MaterialTheme.colorScheme.background
         ) {
-            if (selectedTab == 2) {
-                SmsListScreen(smsModel, contactsModel)
-            } else {
-                ContactsPage(
-                    nestedScrollConnection.takeIf { themeModel.collapsableBottomBar },
-                    bottomBarOffsetHeight = with(LocalDensity.current) {
-                        bottomBarHeight - bottomBarOffsetHeightPx.value.absoluteValue.toDp()
-                    }.takeIf { themeModel.collapsableBottomBar } ?: 0.dp
-                )
+            Crossfade(targetState = currentPage, label = "crossfade pager") { index ->
+                when (index) {
+                    0, 1 -> ContactsPage(
+                        nestedScrollConnection.takeIf { themeModel.collapsableBottomBar },
+                        bottomBarOffsetHeight = with(LocalDensity.current) {
+                            bottomBarHeight - bottomBarOffsetHeightPx.value.absoluteValue.toDp()
+                        }.takeIf { themeModel.collapsableBottomBar } ?: 0.dp,
+                        ContactsSource.values()[index]
+                    )
+
+                    2 -> SmsListScreen(smsModel, contactsModel)
+                }
             }
         }
     }

--- a/app/src/main/java/com/bnyro/contacts/ui/screens/MainAppContent.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/screens/MainAppContent.kt
@@ -61,8 +61,11 @@ fun MainAppContent(smsModel: SmsModel) {
     val bottomBarOffsetHeightPx = remember { mutableStateOf(0f) }
 
     var selectedTab by remember {
-        val tab = if (smsModel.initialAddressAndBody != null) 2
-        else Preferences.getInt(Preferences.homeTabKey, 0)
+        val tab = if (smsModel.initialAddressAndBody != null) {
+            2
+        } else {
+            Preferences.getInt(Preferences.homeTabKey, 0)
+        }
         mutableIntStateOf(tab)
     }
 
@@ -76,7 +79,7 @@ fun MainAppContent(smsModel: SmsModel) {
         }
     }
 
-    LaunchedEffect(contactsModel.isLoading) {
+    LaunchedEffect(contactsModel.contactListState) {
         contactsModel.initialContactId ?: return@LaunchedEffect
         contactsModel.contacts.firstOrNull {
             it.contactId == contactsModel.initialContactId

--- a/app/src/main/java/com/bnyro/contacts/util/LocalContactsRepository.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/LocalContactsRepository.kt
@@ -128,6 +128,7 @@ class LocalContactsRepository(context: Context) : ContactsRepository {
         }
     }
 
+    @Deprecated("Useless function")
     override suspend fun loadAdvancedData(contact: ContactData): ContactData = contact
     override fun isAutoBackupEnabled(): Boolean {
         return Preferences.getBackupType() in listOf(BackupType.BOTH, BackupType.LOCAL)


### PR DESCRIPTION
I had to add some boilerplate code in ContactModel to make it compatible with some of the older code base.

Apart from that, I did the following changes to increase performance
- Used a `ContactListState` interface instead of `isLoading` to make the loading of each source independent.
- Optimized contact list performance (reduce laggy behavior when scrolling and tab switching) [^1]
- Remove permission checking while loop from the composable function and move it to the `viewModel`
- Moved the permission request logic from `viewModel` to `BaseActivity`
- Moved the coroutine context switching logic (`withContext(Dispatcher.IO)`) from viewModel to ContactRepository
- Moved the InitialContact loading logic from composable function to viewModel [^2]

[^1]: used `remember` to avoid recomputing the contact groups during re-compositions.
[^2]: I couldn't find a proper way to test this. According to my testing it worked similar to the v6.0
