### PR TITLE
Allow filtering of individual accounts

### DIFF
--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactsPage.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactsPage.kt
@@ -308,7 +308,7 @@ fun ContactsPage(
                         it.displayName.orEmpty().lowercase().contains(query) ||
                             it.numbers.any { number -> number.value.contains(query) }
                     }.filter {
-                        !filterOptions.hiddenAccountNames.contains(it.accountName)
+                        !filterOptions.hiddenAccountNames.contains(it.accountType + "|" + it.accountName)
                     }.filter {
                         if (filterOptions.visibleGroups.isEmpty()) {
                             true

--- a/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
@@ -71,10 +71,11 @@ fun FilterDialog(
                         title = stringResource(R.string.account_type),
                         entries = availableAccountTypes.map { it.second },
                         selections = availableAccountTypes.filter {
-                            !hiddenAccountNames.contains(it.second)
+                            !hiddenAccountNames.contains(it.first + "|" + it.second)
                         }.map { it.second },
                         onSelectionChanged = { index, newValue ->
-                            val selectedAccountName = availableAccountTypes[index].second
+                            val selection = availableAccountTypes[index]
+                            val selectedAccountName = selection.first + "|" + selection.second
                             hiddenAccountNames = if (newValue) {
                                 hiddenAccountNames - selectedAccountName
                             } else {

--- a/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
@@ -71,14 +71,14 @@ fun FilterDialog(
                         title = stringResource(R.string.account_type),
                         entries = availableAccountTypes.map { it.second },
                         selections = availableAccountTypes.filter {
-                            !hiddenAccountNames.contains(it.first)
+                            !hiddenAccountNames.contains(it.second)
                         }.map { it.second },
                         onSelectionChanged = { index, newValue ->
-                            val selectedAccountType = availableAccountTypes[index].first
+                            val selectedAccountName = availableAccountTypes[index].second
                             hiddenAccountNames = if (newValue) {
-                                hiddenAccountNames - selectedAccountType
+                                hiddenAccountNames - selectedAccountName
                             } else {
-                                hiddenAccountNames + selectedAccountType
+                                hiddenAccountNames + selectedAccountName
                             }
                         }
                     )


### PR DESCRIPTION
The existing behaviour toggles all accounts from a single provider when one of them is selected in the filter dialog.

This change means selections are managed by account name rather than type, in order to allow filtering on individual accounts.

For context, I use DAVx5 with a set of three address books, one current and two for old/archived contacts -- day-to-day I'm only interested in the current contacts.