### PR TITLE
Allow filtering of individual accounts

### DIFF
--- a/app/src/main/java/com/bnyro/contacts/obj/ContactData.kt
+++ b/app/src/main/java/com/bnyro/contacts/obj/ContactData.kt
@@ -25,11 +25,20 @@ data class ContactData(
     var groups: List<ContactsGroup> = listOf(),
     var websites: List<ValueWithType> = listOf()
 ) {
+    /**
+     * Unique identifier for a device contacts storage account
+     */
+    val accountIdentifier get() = "${accountType.orEmpty()}${ACCOUNT_SEPARATOR}${accountName.orEmpty()}"
+
     fun getNameBySortOrder(sortOrder: SortOrder): String? {
         return when (sortOrder) {
             SortOrder.FIRSTNAME -> displayName
             SortOrder.LASTNAME -> alternativeName
             SortOrder.NICKNAME -> nickName ?: displayName
         }
+    }
+
+    companion object {
+        const val ACCOUNT_SEPARATOR = "|"
     }
 }

--- a/app/src/main/java/com/bnyro/contacts/obj/FilterOptions.kt
+++ b/app/src/main/java/com/bnyro/contacts/obj/FilterOptions.kt
@@ -5,7 +5,7 @@ import com.bnyro.contacts.util.Preferences
 
 data class FilterOptions(
     var sortOder: SortOrder,
-    var hiddenAccountNames: List<String>,
+    var hiddenAccountIdentifiers: List<String>,
     var visibleGroups: List<ContactsGroup>
 ) {
     companion object {

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactEditor.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactEditor.kt
@@ -428,9 +428,10 @@ fun ContactEditor(
                 LazyColumn(
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    items(availableAccounts) {
-                        ClickableText(text = it.second) {
-                            selectedAccount = it
+                    items(availableAccounts) { identifier ->
+                        val accountParts = identifier.split(ContactData.ACCOUNT_SEPARATOR)
+                        ClickableText(text = "${accountParts.first()} (${accountParts.last()})") {
+                            selectedAccount = accountParts.first() to accountParts.last()
                             showAccountTypeDialog = false
                         }
                     }

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactsList.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactsList.kt
@@ -28,7 +28,7 @@ fun ContactsList(
     val state = rememberLazyListState()
     val contactGroups = remember(contacts) {
         contacts.asSequence().filter {
-            !filterOptions.hiddenAccountNames.contains(it.accountName)
+            !filterOptions.hiddenAccountIdentifiers.contains(it.accountIdentifier)
         }.filter {
             if (filterOptions.visibleGroups.isEmpty()) {
                 true

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactsPage.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactsPage.kt
@@ -383,7 +383,7 @@ fun ContactsPage(
                 filterOptions = it
             },
             initialFilters = filterOptions,
-            availableAccountTypes = viewModel.getAvailableAccounts(),
+            availableAccountIdentifiers = viewModel.getAvailableAccounts(),
             availableGroups = viewModel.getAvailableGroups()
         )
     }

--- a/app/src/main/java/com/bnyro/contacts/ui/models/ContactsModel.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/models/ContactsModel.kt
@@ -203,15 +203,16 @@ class ContactsModel(
     /**
      * Returns a list of account type to account name
      */
-    fun getAvailableAccounts(): List<Pair<String, String>> {
+    fun getAvailableAccounts(): List<String> {
         if (contacts.isEmpty()) {
             return listOf(
-                DeviceContactsRepository.ANDROID_ACCOUNT_TYPE to DeviceContactsRepository.ANDROID_CONTACTS_NAME
+                DeviceContactsRepository.ANDROID_ACCOUNT_TYPE + ContactData.ACCOUNT_SEPARATOR + DeviceContactsRepository.ANDROID_CONTACTS_NAME
             )
         }
-        return contacts.mapNotNull {
-            it.accountType?.let { type -> type to it.accountName.orEmpty() }
-        }.distinct().toMutableList()
+        return contacts
+            .filter { it.accountType != null }
+            .map { it.accountIdentifier }
+            .distinct()
     }
 
     fun getAvailableGroups() = contacts.map { it.groups }.flatten().distinct()


### PR DESCRIPTION
The existing behaviour toggles all accounts from a single provider when one of them is selected in the filter dialog.

This change means selections are managed by account name rather than type, in order to allow filtering on individual accounts.

I had to open a new PR because #238 blocked write access.