### PR TITLE
Allow filtering of individual accounts (v2)

### DIFF
--- a/app/src/main/java/com/bnyro/contacts/obj/ContactData.kt
+++ b/app/src/main/java/com/bnyro/contacts/obj/ContactData.kt
@@ -25,6 +25,7 @@ data class ContactData(
     var groups: List<ContactsGroup> = listOf(),
     var websites: List<ValueWithType> = listOf()
 ) {
+    val accountIdentifier get() = "$accountType|$accountName"
     fun getNameBySortOrder(sortOrder: SortOrder): String? {
         return when (sortOrder) {
             SortOrder.FIRSTNAME -> displayName

--- a/app/src/main/java/com/bnyro/contacts/obj/FilterOptions.kt
+++ b/app/src/main/java/com/bnyro/contacts/obj/FilterOptions.kt
@@ -5,7 +5,7 @@ import com.bnyro.contacts.util.Preferences
 
 data class FilterOptions(
     var sortOder: SortOrder,
-    var hiddenAccountNames: List<String>,
+    var hiddenAccountIdentifiers: List<String>,
     var visibleGroups: List<ContactsGroup>
 ) {
     companion object {

--- a/app/src/main/java/com/bnyro/contacts/obj/FilterOptions.kt
+++ b/app/src/main/java/com/bnyro/contacts/obj/FilterOptions.kt
@@ -11,7 +11,8 @@ data class FilterOptions(
     companion object {
         fun default(): FilterOptions {
             val sortOrder = SortOrder.fromInt(Preferences.getInt(Preferences.sortOrderKey, 0))
-            return FilterOptions(sortOrder, listOf(), listOf())
+            val hiddenAccounts = Preferences.getStringSet(Preferences.hiddenAccountsKey, emptySet())!!.toList()
+            return FilterOptions(sortOrder, hiddenAccounts, listOf())
         }
     }
 }

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactsList.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactsList.kt
@@ -28,7 +28,7 @@ fun ContactsList(
     val state = rememberLazyListState()
     val contactGroups = remember(contacts) {
         contacts.asSequence().filter {
-            !filterOptions.hiddenAccountNames.contains(it.accountName)
+            !filterOptions.hiddenAccountIdentifiers.contains(it.accountIdentifier)
         }.filter {
             if (filterOptions.visibleGroups.isEmpty()) {
                 true

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactsPage.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactsPage.kt
@@ -379,7 +379,10 @@ fun ContactsPage(
                 showFilterDialog = false
             },
             onFilterChanged = {
-                Preferences.edit { putInt(Preferences.sortOrderKey, it.sortOder.ordinal) }
+                Preferences.edit {
+                    putInt(Preferences.sortOrderKey, it.sortOder.ordinal)
+                    putStringSet(Preferences.hiddenAccountsKey, it.hiddenAccountIdentifiers.toSet())
+                }
                 filterOptions = it
             },
             initialFilters = filterOptions,

--- a/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
@@ -71,10 +71,11 @@ fun FilterDialog(
                         title = stringResource(R.string.account_type),
                         entries = availableAccountTypes.map { it.second },
                         selections = availableAccountTypes.filter {
-                            !hiddenAccountNames.contains(it.second)
+                            !hiddenAccountNames.contains(it.first + "|" + it.second)
                         }.map { it.second },
                         onSelectionChanged = { index, newValue ->
-                            val selectedAccountName = availableAccountTypes[index].second
+                            val selection = availableAccountTypes[index]
+                            val selectedAccountName = selection.first + "|" + selection.second
                             hiddenAccountNames = if (newValue) {
                                 hiddenAccountNames - selectedAccountName
                             } else {

--- a/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
@@ -71,14 +71,14 @@ fun FilterDialog(
                         title = stringResource(R.string.account_type),
                         entries = availableAccountTypes.map { it.second },
                         selections = availableAccountTypes.filter {
-                            !hiddenAccountNames.contains(it.first)
+                            !hiddenAccountNames.contains(it.second)
                         }.map { it.second },
                         onSelectionChanged = { index, newValue ->
-                            val selectedAccountType = availableAccountTypes[index].first
+                            val selectedAccountName = availableAccountTypes[index].second
                             hiddenAccountNames = if (newValue) {
-                                hiddenAccountNames - selectedAccountType
+                                hiddenAccountNames - selectedAccountName
                             } else {
-                                hiddenAccountNames + selectedAccountType
+                                hiddenAccountNames + selectedAccountName
                             }
                         }
                     )

--- a/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/dialogs/FilterDialog.kt
@@ -31,7 +31,7 @@ fun FilterDialog(
     }
 
     var hiddenAccountNames by remember {
-        mutableStateOf(initialFilters.hiddenAccountNames)
+        mutableStateOf(initialFilters.hiddenAccountIdentifiers)
     }
 
     var visibleGroups by remember {

--- a/app/src/main/java/com/bnyro/contacts/util/Preferences.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/Preferences.kt
@@ -19,6 +19,7 @@ object Preferences {
     const val backupDirKey = "backupDir"
     const val backupTypeKey = "backupType"
     const val sortOrderKey = "sorting"
+    const val hiddenAccountsKey = "hiddenAccounts"
     const val backupIntervalKey = "backupInterval"
     const val maxBackupAmountKey = "maxBackupAmount"
     const val collapseBottomBarKey = "collapseBottomBar"
@@ -33,6 +34,7 @@ object Preferences {
     fun getBoolean(key: String, defValue: Boolean) = preferences.getBoolean(key, defValue)
     fun getString(key: String, defValue: String) = preferences.getString(key, defValue)
     fun getInt(key: String, defValue: Int) = preferences.getInt(key, defValue)
+    fun getStringSet(key: String, defValue: Set<String>) = preferences.getStringSet(key, defValue)
 
     fun edit(action: SharedPreferences.Editor.() -> Unit) {
         preferences.edit().apply(action).apply()


### PR DESCRIPTION
Rebase of #238, replaces #257.

This adds the missing persistence of hidden accounts so that the filters actually work, as they don't seem to actually be stored anywhere at present (would've been useful to know that up front!).  Note that groups are also lacking persistence, but I'm not immediately sure what that should look like.

I haven't made any of the UI changes suggested in https://github.com/you-apps/ConnectYou/pull/257#issuecomment-1712170918, besides reducing the labels on each selection item to just the account names.