### PR TITLE
fix: set search text field to single line

### DIFF
--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactSearchScreen.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactSearchScreen.kt
@@ -85,7 +85,8 @@ fun ContactSearchScreen(
                 leadingIcon = Icons.Default.Search,
                 placeholder = stringResource(id = R.string.search),
                 imeAction = ImeAction.Done,
-                focusRequester = focusRequester
+                focusRequester = focusRequester,
+                singleLine = true
             )
             ContactsList(
                 contacts = visibleContacts,

--- a/app/src/main/java/com/bnyro/contacts/ui/components/base/ElevatedTextInputField.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/base/ElevatedTextInputField.kt
@@ -29,6 +29,7 @@ fun ElevatedTextInputField(
     placeholder: String? = null,
     leadingIcon: ImageVector? = null,
     imeAction: ImeAction = ImeAction.Default,
+    singleLine: Boolean = false,
     focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
     TextField(
@@ -52,6 +53,7 @@ fun ElevatedTextInputField(
             focusedIndicatorColor = Color.Transparent,
             unfocusedIndicatorColor = Color.Transparent
         ),
-        keyboardOptions = KeyboardOptions(imeAction = imeAction)
+        keyboardOptions = KeyboardOptions(imeAction = imeAction),
+        singleLine = singleLine,
     )
 }


### PR DESCRIPTION
Fixes an issue, where multiple lines could be entered, expanding the search text field.

![Search entry with multiple lines](https://github.com/you-apps/ConnectYou/assets/63370021/cc16a06c-246c-4d63-92a6-9685b4b8d38d)
