### PR TITLE
refactor: simplify contacts logic and remove duplicated code

### DIFF
--- a/app/src/main/java/com/bnyro/contacts/enums/ContactAttributes.kt
+++ b/app/src/main/java/com/bnyro/contacts/enums/ContactAttributes.kt
@@ -1,0 +1,164 @@
+package com.bnyro.contacts.enums
+
+import android.provider.ContactsContract
+import android.provider.ContactsContract.Intents
+import com.bnyro.contacts.R
+import com.bnyro.contacts.obj.ContactData
+import com.bnyro.contacts.obj.TranslatedType
+import com.bnyro.contacts.obj.ValueWithType
+import com.bnyro.contacts.util.ContactsHelper
+
+abstract class ContactAttribute<T>(){
+    abstract val stringRes: Int
+    abstract val androidValueColumn: String
+    abstract val androidContentType: String
+    abstract fun set(contact: ContactData, value: T)
+    abstract fun get(contact: ContactData): T
+}
+
+abstract class StringAttribute : ContactAttribute<String?>() {
+    abstract val insertKey: String?
+}
+
+abstract class ListAttribute: ContactAttribute<List<ValueWithType>>() {
+    abstract val androidTypeColumn: String
+    abstract val types: List<TranslatedType>
+    abstract val insertKeys: List<Pair<String, String?>>
+}
+
+class Organization : StringAttribute() {
+    override val stringRes: Int = R.string.organization
+    override val insertKey: String = Intents.Insert.COMPANY
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.Organization.COMPANY
+    override val androidContentType: String = ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE
+
+    override fun set(contact: ContactData, value: String?) {
+        contact.organization = value
+    }
+
+    override fun get(contact: ContactData) = contact.organization
+}
+
+class Title : StringAttribute() {
+    override val stringRes: Int = R.string.title
+    override val insertKey: String = Intents.Insert.JOB_TITLE
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.Organization.TITLE
+    override val androidContentType: String = ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE
+
+    override fun set(contact: ContactData, value: String?) {
+        contact.organization = value
+    }
+
+    override fun get(contact: ContactData) = contact.organization
+}
+
+class Nickname : StringAttribute() {
+    override val stringRes: Int = R.string.nick_name
+    override val insertKey: String? = null
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.Nickname.NAME
+    override val androidContentType: String = ContactsContract.CommonDataKinds.Nickname.CONTENT_ITEM_TYPE
+
+    override fun set(contact: ContactData, value: String?) {
+        contact.nickName = value
+    }
+
+    override fun get(contact: ContactData) = contact.nickName
+}
+
+class Events : ListAttribute() {
+    override val stringRes: Int = R.string.event
+    override val insertKeys: List<Pair<String, String?>> = emptyList()
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.Event.START_DATE
+    override val androidTypeColumn: String = ContactsContract.CommonDataKinds.Event.TYPE
+    override val androidContentType: String = ContactsContract.CommonDataKinds.Event.CONTENT_ITEM_TYPE
+    override fun set(contact: ContactData, value: List<ValueWithType>) {
+        contact.events = value
+    }
+
+    override fun get(contact: ContactData) = contact.events
+
+    override val types: List<TranslatedType> = ContactsHelper.eventTypes
+}
+
+class Numbers : ListAttribute() {
+    override val stringRes: Int = R.string.phone_number
+    override val insertKeys: List<Pair<String, String?>> = listOf(
+        Intents.Insert.PHONE to Intents.Insert.PHONE_TYPE,
+        Intents.Insert.SECONDARY_PHONE to Intents.Insert.SECONDARY_PHONE,
+        Intents.Insert.TERTIARY_EMAIL to Intents.Insert.TERTIARY_EMAIL_TYPE
+    )
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.Phone.NUMBER
+    override val androidTypeColumn: String = ContactsContract.CommonDataKinds.Phone.TYPE
+    override val androidContentType: String = ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE
+    override fun set(contact: ContactData, value: List<ValueWithType>) {
+        contact.numbers = value
+    }
+
+    override fun get(contact: ContactData) = contact.numbers
+
+    override val types: List<TranslatedType> = ContactsHelper.phoneNumberTypes
+}
+
+class Emails : ListAttribute() {
+    override val stringRes: Int = R.string.email
+    override val insertKeys: List<Pair<String, String?>> = listOf(
+        Intents.Insert.EMAIL to Intents.Insert.EMAIL_TYPE,
+        Intents.Insert.SECONDARY_EMAIL to Intents.Insert.SECONDARY_EMAIL_TYPE,
+        Intents.Insert.TERTIARY_EMAIL to Intents.Insert.TERTIARY_EMAIL_TYPE
+    )
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.Email.ADDRESS
+    override val androidTypeColumn: String = ContactsContract.CommonDataKinds.Email.TYPE
+    override val androidContentType: String = ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE
+    override fun set(contact: ContactData, value: List<ValueWithType>) {
+        contact.emails = value
+    }
+
+    override fun get(contact: ContactData) = contact.emails
+
+    override val types: List<TranslatedType> = ContactsHelper.emailTypes
+}
+
+class Addresses : ListAttribute() {
+    override val stringRes: Int = R.string.address
+    override val insertKeys: List<Pair<String, String?>> = listOf(Intents.Insert.POSTAL to null)
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.StructuredPostal.FORMATTED_ADDRESS
+    override val androidTypeColumn: String = ContactsContract.CommonDataKinds.StructuredPostal.TYPE
+    override val androidContentType: String = ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE
+    override fun set(contact: ContactData, value: List<ValueWithType>) {
+        contact.addresses = value
+    }
+
+    override fun get(contact: ContactData) = contact.addresses
+
+    override val types: List<TranslatedType> = ContactsHelper.addressTypes
+}
+
+class Notes : ListAttribute() {
+    override val stringRes: Int = R.string.note
+    override val insertKeys: List<Pair<String, String?>> = listOf(Intents.Insert.NOTES to null)
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.Note.NOTE
+    override val androidTypeColumn: String = ContactsContract.CommonDataKinds.Note.DATA2
+    override val androidContentType: String = ContactsContract.CommonDataKinds.Note.CONTENT_ITEM_TYPE
+    override fun set(contact: ContactData, value: List<ValueWithType>) {
+        contact.notes = value
+    }
+
+    override fun get(contact: ContactData) = contact.notes
+
+    override val types: List<TranslatedType> = emptyList()
+}
+
+class Websites : ListAttribute() {
+    override val stringRes: Int = R.string.website
+    override val insertKeys: List<Pair<String, String?>> = emptyList()
+    override val androidValueColumn: String = ContactsContract.CommonDataKinds.Website.URL
+    override val androidTypeColumn: String = ContactsContract.CommonDataKinds.Website.TYPE
+    override val androidContentType: String = ContactsContract.CommonDataKinds.Website.CONTENT_ITEM_TYPE
+    override fun set(contact: ContactData, value: List<ValueWithType>) {
+        contact.websites = value
+    }
+
+    override fun get(contact: ContactData) = contact.websites
+
+    override val types: List<TranslatedType> = ContactsHelper.websiteTypes
+}

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ContactEditor.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ContactEditor.kt
@@ -359,6 +359,7 @@ fun ContactEditor(
                     TextFieldGroup(
                         items = websites,
                         label = R.string.website,
+                        types = ContactsHelper.websiteTypes,
                         addActionText = R.string.add_website,
                         keyboardType = KeyboardType.Uri,
                         leadingIcon = Icons.Outlined.Web

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ShareDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ShareDialog.kt
@@ -4,20 +4,23 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bnyro.contacts.R
+import com.bnyro.contacts.enums.ListAttribute
+import com.bnyro.contacts.enums.StringAttribute
 import com.bnyro.contacts.obj.ContactData
 import com.bnyro.contacts.ui.components.dialogs.DialogButton
 import com.bnyro.contacts.ui.models.ContactsModel
 import com.bnyro.contacts.util.BackupHelper
+import com.bnyro.contacts.util.ContactsHelper
 
 @Composable
 fun ShareDialog(
@@ -27,48 +30,46 @@ fun ShareDialog(
     val contactsModel: ContactsModel = viewModel(factory = ContactsModel.Factory)
     val context = LocalContext.current
 
-    val shareName = remember { mutableStateOf(true) }
-    val sharePhoto = remember { mutableStateOf(true) }
-    val shareNickName = remember { mutableStateOf(true) }
-    val shareTitle = remember { mutableStateOf(true) }
-    val shareOrganization = remember { mutableStateOf(true) }
-    val shareWebsite = remember { mutableStateOf(true) }
-    val sharePhone = remember { mutableStateOf(true) }
-    val shareEmail = remember { mutableStateOf(true) }
-    val shareAddress = remember { mutableStateOf(true) }
-    val shareNote = remember { mutableStateOf(true) }
+    val baseOptions = remember {
+        listOf(R.string.name, R.string.photo)
+    }
 
-    val options = listOf(
-        R.string.name to shareName,
-        R.string.photo to sharePhoto,
-        R.string.title to shareTitle,
-        R.string.nick_name to shareNickName,
-        R.string.organization to shareOrganization,
-        R.string.website to shareWebsite,
-        R.string.phone to sharePhone,
-        R.string.email to shareEmail,
-        R.string.address to shareAddress,
-        R.string.note to shareNote
-    )
+    val options = remember {
+         baseOptions + ContactsHelper.contactAttributesTypes.map { it.stringRes }
+    }
+
+    val selected = remember {
+        SnapshotStateList<Boolean>().apply {
+            for (i in options.indices) add(true)
+        }
+    }
 
     fun getContactData(): ContactData {
-        return contact.copy().apply {
-            if (!shareName.value) {
-                displayName = null
-                alternativeName = null
-                firstName = null
-                surName = null
-            }
-            if (!sharePhoto.value) photo = null
-            if (!shareNickName.value) nickName = null
-            if (!shareTitle.value) title = null
-            if (!shareOrganization.value) organization = null
-            if (!shareAddress.value) addresses = emptyList()
-            if (!shareEmail.value) emails = emptyList()
-            if (!shareNote.value) notes = emptyList()
-            if (!sharePhone.value) numbers = emptyList()
-            if (!shareWebsite.value) websites = emptyList()
+        val data = ContactData()
+
+        if (selected[0]) {
+            data.displayName = contact.displayName
+            data.alternativeName = contact.alternativeName
+            data.firstName = contact.firstName
+            data.surName = contact.surName
         }
+        if (selected[1]) {
+            data.photo = contact.photo
+        }
+
+        ContactsHelper.contactAttributesTypes.forEachIndexed { index, contactAttribute ->
+            if (selected[index + baseOptions.size]) {
+                if (contactAttribute is StringAttribute) {
+                    val value = contactAttribute.get(contact)
+                    contactAttribute.set(data, value)
+                } else if (contactAttribute is ListAttribute) {
+                    val value = contactAttribute.get(contact)
+                    contactAttribute.set(data, value)
+                }
+            }
+        }
+
+        return data
     }
 
     val openFilePicker = rememberLauncherForActivityResult(
@@ -86,8 +87,10 @@ fun ShareDialog(
         title = { Text(stringResource(R.string.share)) },
         text = {
             LazyColumn {
-                items(options) {
-                    ShareOption(title = it.first, isChecked = it.second)
+                itemsIndexed(options) { index, it ->
+                    ShareOption(title = it, isChecked = selected[index]) {
+                        selected[index] = it
+                    }
                 }
             }
         },

--- a/app/src/main/java/com/bnyro/contacts/ui/components/ShareOption.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/components/ShareOption.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -17,13 +16,14 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun ShareOption(
     @StringRes title: Int,
-    isChecked: MutableState<Boolean>
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Checkbox(checked = isChecked.value, onCheckedChange = { isChecked.value = it })
+        Checkbox(checked = isChecked, onCheckedChange = onCheckedChange)
         Spacer(modifier = Modifier.width(10.dp))
         Text(text = stringResource(title))
     }

--- a/app/src/main/java/com/bnyro/contacts/ui/screens/SingleContactScreen.kt
+++ b/app/src/main/java/com/bnyro/contacts/ui/screens/SingleContactScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -66,7 +65,7 @@ import com.bnyro.contacts.util.CalendarUtils
 import com.bnyro.contacts.util.ContactsHelper
 import com.bnyro.contacts.util.IntentHelper
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SingleContactScreen(contact: ContactData, onClose: () -> Unit) {
     val viewModel: ContactsModel = viewModel()

--- a/app/src/main/java/com/bnyro/contacts/util/ContactsHelper.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/ContactsHelper.kt
@@ -2,6 +2,15 @@ package com.bnyro.contacts.util
 
 import android.provider.ContactsContract
 import com.bnyro.contacts.R
+import com.bnyro.contacts.enums.Addresses
+import com.bnyro.contacts.enums.Emails
+import com.bnyro.contacts.enums.Events
+import com.bnyro.contacts.enums.Nickname
+import com.bnyro.contacts.enums.Notes
+import com.bnyro.contacts.enums.Numbers
+import com.bnyro.contacts.enums.Organization
+import com.bnyro.contacts.enums.Title
+import com.bnyro.contacts.enums.Websites
 import com.bnyro.contacts.obj.ContactData
 import com.bnyro.contacts.obj.TranslatedType
 import com.google.i18n.phonenumbers.PhoneNumberUtil
@@ -75,6 +84,11 @@ object ContactsHelper {
         TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_FTP, R.string.ftp),
         TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_CUSTOM, R.string.custom),
         TranslatedType(ContactsContract.CommonDataKinds.Website.TYPE_OTHER, R.string.other)
+    )
+
+    val contactAttributesTypes = listOf(
+        Nickname(), Title(), Organization(),
+        Numbers(), Addresses(), Emails(), Events(), Websites(), Notes()
     )
 
     fun splitFullName(displayName: String?): Pair<String, String> {


### PR DESCRIPTION
This prevents issues if we possibly add more contact fields in the future and makes it easier to maintain.

We should likely use this for the `SingleContactsScreen` and the `ContactsEditor` too in the future, to clean things up and make it easier to add more contact fields.