### PR TITLE
 Removed translation of app_name (Except Bengali)

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -22,7 +22,6 @@
     <string name="import_success">Importiert.</string>
     <string name="share">Teilen</string>
     <string name="export_success">Exportiert.</string>
-    <string name="app_name">Connect You</string>
     <string name="custom">Benutzerdefiniert</string>
     <string name="translation">Übersetzung</string>
     <string name="version">Version</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,7 +10,6 @@
     <string name="author">Auteur·e</string>
     <string name="version">Version</string>
     <string name="translation">Traduction</string>
-    <string name="app_name">Connect You</string>
     <string name="copied">Copié dans le presse-papier</string>
     <string name="delete_contact">Supprimer le contact</string>
     <string name="cancel">Annuler</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Connect You</string>
     <string name="delete_contact">Slett kontakt</string>
     <string name="birthday">Geburtsdag</string>
     <string name="anniversary">Jubileum</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -32,7 +32,6 @@
     <string name="translation">Çeviri</string>
     <string name="import_success">İçe aktarıldı.</string>
     <string name="phone">Telefon</string>
-    <string name="app_name">Connect You</string>
     <string name="copied">Panoya kopyalandı</string>
     <string name="irreversible">Emin misiniz? Bu geri alınamaz!</string>
     <string name="cancel">İptal</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="translation">Переклад</string>
-    <string name="app_name">Connect You</string>
     <string name="delete_contact">Видалити контакт</string>
     <string name="cancel">Скасувати</string>
     <string name="search" tools:ignore="PrivateResource">Пошук</string>


### PR DESCRIPTION
But in https://github.com/you-apps/ConnectYou/blob/main/app/src/main/res/values-bn/strings.xml, there is a real translation, not a copy of the original string, what to do with this think for yourself