### PR TITLE
fix(proguard): preserve constructors for ezvcard properties and parameters

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Keep constructors and members for both properties and parameters
+-keep,includedescriptorclasses class ezvcard.parameter.** { <init>(...); *; }
+-keep,includedescriptorclasses class ezvcard.property.** { <init>(...); *; }


### PR DESCRIPTION
- Fixes a runtime `NoSuchMethodException` when R8/ProGuard shrinks the reflection-targeted 3-string constructor `<init>(String, String, String)` for `ImageType`.
- Explicitly kept constructors for parameter and property packages

Fixes #486 #486 #484 
