### PR TITLE
Fix #477: "Device" contacts get deleted by account changes from across the system

### DIFF
--- a/app/src/main/java/com/bnyro/contacts/App.kt
+++ b/app/src/main/java/com/bnyro/contacts/App.kt
@@ -57,6 +57,10 @@ class App : Application() {
             ShortcutHelper.createShortcuts(this@App)
         }
 
+        CoroutineScope(Dispatchers.IO).launch {
+            deviceContactsRepository.migrateContactsFromLegacyDeviceAccount()
+        }
+
         initSmsRepo()
     }
 }

--- a/app/src/main/java/com/bnyro/contacts/domain/model/AccountType.kt
+++ b/app/src/main/java/com/bnyro/contacts/domain/model/AccountType.kt
@@ -1,18 +1,95 @@
 package com.bnyro.contacts.domain.model
 
-data class AccountType(
-    val name: String,
-    val type: String,
-) {
-    val identifier = "$type|$name"
+import android.util.Log
+
+sealed interface AccountType {
+    fun displayName(): String
+    fun displayType(): String
+
+    data class AccountColumns(
+        val accountName: String?,
+        val accountType: String?,
+    )
+
+    fun toAccountColumns(): AccountColumns {
+        return when (this) {
+            is DeviceAccountType -> AccountColumns(null, null)
+            is RealAccountType -> AccountColumns(accountName = this.name, accountType = this.type)
+        }
+    }
+
+    fun toPreferencesString(): String {
+        val (name, type) = when (this) {
+            is DeviceAccountType -> Pair(
+                DeviceAccountType.LEGACY_NAME,
+                DeviceAccountType.LEGACY_TYPE
+            )
+            is RealAccountType -> Pair(this.name, this.type)
+        }
+        return "${type}|${name}"
+    }
 
     companion object {
-        private const val ANDROID_ACCOUNT_TYPE = "com.android.contacts"
-        private const val ANDROID_ACCOUNT_NAME = "DEVICE"
+        fun fromAccountColumns(accountName: String?, accountType: String?): AccountType? {
+            return if (accountName == null && accountType == null) {
+                DeviceAccountType
+            } else if (accountName != null && accountType != null) {
+                fromNameAndType(accountName, accountType)
+            } else {
+                Log.e("AccountType", "Raw contact has partial account: name=($accountName),type=($accountType)")
+                null
+            }
+        }
 
-        val androidDefault = AccountType(
-            ANDROID_ACCOUNT_NAME,
-            ANDROID_ACCOUNT_TYPE
-        )
+        fun fromPreferencesString(identifier: String): AccountType? {
+            val sections = identifier.split('|')
+            if (sections.size != 2) return null
+            val type = sections[0]
+            val name = sections[1]
+            return fromNameAndType(name, type)
+        }
+
+        private fun fromNameAndType(name: String, type: String): AccountType {
+            return if (type == DeviceAccountType.LEGACY_TYPE
+                    && name == DeviceAccountType.LEGACY_NAME
+            ) {
+                // This is for contacts saved before the fix for #477
+                DeviceAccountType
+            } else {
+                RealAccountType(name, type)
+            }
+        }
+    }
+}
+
+data object DeviceAccountType: AccountType {
+    /* The legacy signifiers here are very important.  We must always
+      be able to deserialize objects from previous versions of the app -
+      to do that we must know these exact values. */
+    internal const val LEGACY_TYPE: String = "com.android.contacts"
+    internal const val LEGACY_NAME: String = "DEVICE"
+
+    override fun displayName(): String {
+        // TODO: retrieve a localised value instead
+        // e.g. Through context.getString(R.string.device)
+        return "Device"
+    }
+
+    override fun displayType(): String {
+        // TODO choose new value
+        return "com.android.contacts"
+    }
+}
+
+data class RealAccountType(
+    val name: String,
+    val type: String,
+): AccountType {
+    override fun displayName(): String {
+        return name
+    }
+
+    override fun displayType(): String {
+        return type
     }
 }

--- a/app/src/main/java/com/bnyro/contacts/domain/model/ContactData.kt
+++ b/app/src/main/java/com/bnyro/contacts/domain/model/ContactData.kt
@@ -8,8 +8,7 @@ data class ContactData(
     var dataId: Int = 0,
     var rawContactId: Int = 0,
     var contactId: Long = 0,
-    var accountType: String? = null,
-    var accountName: String? = null,
+    var account: AccountType? = null,
     var displayName: String? = null,
     var alternativeName: String? = null,
     var firstName: String? = null,
@@ -29,7 +28,6 @@ data class ContactData(
     var ringTone: Uri? = null,
     var favorite: Boolean = false
 ) {
-    val accountIdentifier get() = "$accountType|$accountName"
     fun getNameBySortOrder(sortOrder: SortOrder): String? {
         return when (sortOrder) {
             SortOrder.FIRSTNAME -> displayName

--- a/app/src/main/java/com/bnyro/contacts/domain/model/FilterOptions.kt
+++ b/app/src/main/java/com/bnyro/contacts/domain/model/FilterOptions.kt
@@ -5,7 +5,7 @@ import com.bnyro.contacts.util.Preferences
 
 data class FilterOptions(
     var sortOrder: SortOrder,
-    var hiddenAccountIdentifiers: List<String>,
+    var hiddenAccounts: Set<AccountType>,
     var visibleGroups: List<ContactsGroup>,
     var favoritesOnly: Boolean
 ) {
@@ -15,7 +15,9 @@ data class FilterOptions(
             val hiddenAccounts = Preferences.getStringSet(
                 Preferences.hiddenAccountsKey,
                 emptySet()
-            )!!.toList()
+            )!!.mapNotNull {
+                AccountType.fromPreferencesString(it)
+            }.toSet()
             val favoritesOnly = Preferences.getBoolean(Preferences.favoritesOnlyKey, false)
             return FilterOptions(sortOrder, hiddenAccounts, listOf(), favoritesOnly)
         }

--- a/app/src/main/java/com/bnyro/contacts/domain/repositories/DeviceContactsRepository.kt
+++ b/app/src/main/java/com/bnyro/contacts/domain/repositories/DeviceContactsRepository.kt
@@ -28,6 +28,8 @@ import com.bnyro.contacts.domain.enums.StringAttribute
 import com.bnyro.contacts.domain.model.AccountType
 import com.bnyro.contacts.domain.model.ContactData
 import com.bnyro.contacts.domain.model.ContactsGroup
+import com.bnyro.contacts.domain.model.DeviceAccountType
+import com.bnyro.contacts.domain.model.RealAccountType
 import com.bnyro.contacts.domain.model.ValueWithType
 import com.bnyro.contacts.util.ContactsHelper
 import com.bnyro.contacts.util.ImageHelper
@@ -98,8 +100,10 @@ class DeviceContactsRepository(private val context: Context) : ContactsRepositor
                     val contact = ContactData(
                         rawContactId = it.intValue(Data.RAW_CONTACT_ID) ?: 0,
                         contactId = contactId,
-                        accountType = it.stringValue(RawContacts.ACCOUNT_TYPE),
-                        accountName = it.stringValue(RawContacts.ACCOUNT_NAME),
+                        account = AccountType.fromAccountColumns(
+                            accountName = it.stringValue(RawContacts.ACCOUNT_NAME),
+                            accountType = it.stringValue(RawContacts.ACCOUNT_TYPE),
+                        ),
                         displayName = displayName,
                         alternativeName = alternativeName,
                         firstName = firstName,
@@ -167,11 +171,12 @@ class DeviceContactsRepository(private val context: Context) : ContactsRepositor
     override suspend fun createGroup(groupName: String): ContactsGroup? {
         return withContext(Dispatchers.IO) {
             val operations = ArrayList<ContentProviderOperation>()
+            val (accountName, accountType) = DeviceAccountType.toAccountColumns()
             ContentProviderOperation.newInsert(ContactsContract.Groups.CONTENT_URI).apply {
                 withValue(ContactsContract.Groups.TITLE, groupName)
                 withValue(ContactsContract.Groups.GROUP_VISIBLE, 1)
-                withValue(ContactsContract.Groups.ACCOUNT_NAME, AccountType.androidDefault.name)
-                withValue(ContactsContract.Groups.ACCOUNT_TYPE, AccountType.androidDefault.type)
+                withValue(ContactsContract.Groups.ACCOUNT_NAME, accountName)
+                withValue(ContactsContract.Groups.ACCOUNT_TYPE, accountType)
                 operations.add(build())
             }
 
@@ -311,8 +316,7 @@ class DeviceContactsRepository(private val context: Context) : ContactsRepositor
             val lastChosenAccount = Preferences.getLastChosenAccount()
             val ops = listOfNotNull(
                 getCreateAction(
-                    contact.accountType ?: lastChosenAccount.type,
-                    contact.accountName ?: lastChosenAccount.name
+                    contact.account ?: lastChosenAccount
                 ),
                 getInsertAction(
                     StructuredName.CONTENT_ITEM_TYPE,
@@ -437,13 +441,15 @@ class DeviceContactsRepository(private val context: Context) : ContactsRepositor
                     && ContentResolver.getSyncAutomatically(it, AUTHORITY)
         }
 
-        return listOf(AccountType.androidDefault) + accounts.map { AccountType(it.name, it.type) }
+        return listOf<AccountType>(DeviceAccountType) + accounts.map {
+            RealAccountType(it.name, it.type)
+        }
     }
 
     private fun getCreateAction(
-        accountType: String,
-        accountName: String
+        account: AccountType
     ): ContentProviderOperation {
+        val (accountName, accountType) = account.toAccountColumns()
         return ContentProviderOperation.newInsert(RawContacts.CONTENT_URI)
             .withValue(RawContacts.ACCOUNT_TYPE, accountType)
             .withValue(RawContacts.ACCOUNT_NAME, accountName)

--- a/app/src/main/java/com/bnyro/contacts/domain/repositories/DeviceContactsRepository.kt
+++ b/app/src/main/java/com/bnyro/contacts/domain/repositories/DeviceContactsRepository.kt
@@ -6,10 +6,12 @@ import android.annotation.SuppressLint
 import android.content.ContentProviderOperation
 import android.content.ContentResolver
 import android.content.ContentUris
+import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.os.Build
 import android.provider.ContactsContract
 import android.provider.ContactsContract.AUTHORITY
 import android.provider.ContactsContract.CALLER_IS_SYNCADAPTER
@@ -20,6 +22,7 @@ import android.provider.ContactsContract.CommonDataKinds.StructuredName
 import android.provider.ContactsContract.Contacts
 import android.provider.ContactsContract.Data
 import android.provider.ContactsContract.RawContacts
+import android.util.Log
 import androidx.annotation.RequiresPermission
 import com.bnyro.contacts.R
 import com.bnyro.contacts.domain.enums.BackupType
@@ -33,6 +36,7 @@ import com.bnyro.contacts.domain.model.RealAccountType
 import com.bnyro.contacts.domain.model.ValueWithType
 import com.bnyro.contacts.util.ContactsHelper
 import com.bnyro.contacts.util.ImageHelper
+import com.bnyro.contacts.util.PermissionHelper
 import com.bnyro.contacts.util.Preferences
 import com.bnyro.contacts.util.extension.boolValue
 import com.bnyro.contacts.util.extension.intValue
@@ -593,6 +597,83 @@ class DeviceContactsRepository(private val context: Context) : ContactsRepositor
 
             contentResolver.applyBatch(AUTHORITY, arrayListOf(op))
         }
+
+    fun migrateContactsFromLegacyDeviceAccount() {
+        val alreadyMigrated = Preferences.getBoolean(
+            Preferences.legacyDeviceAccountsMigratedKey,
+            false
+        )
+
+        if (!alreadyMigrated
+            && hasPermissionReadWriteContacts()
+            && isLegacyAccountAFakeAccount()
+        ) {
+            runMigration()
+
+            Preferences.edit {
+                putBoolean(
+                    Preferences.legacyDeviceAccountsMigratedKey,
+                    true
+                )
+            }
+        }
+    }
+
+    private fun runMigration() {
+        try {
+            clearLegacyAccountColumns()
+        } catch (error: IllegalArgumentException) {
+            /* At least one version of Samsung Android throws
+             * IllegalArgumentException("Must specify both or neither of ACCOUNT_NAME and ACCOUNT_TYPE")
+             * if you pass in null for both values (despite this being the mentioned "neither" case).
+             */
+            Log.e(
+                "LegacyContactsMigration",
+                "In-place update of contacts with the legacy account values failed. Manufacturer: ${Build.MANUFACTURER}, Model: ${Build.MODEL}",
+                error
+            )
+        }
+    }
+
+    private fun hasPermissionReadWriteContacts(): Boolean {
+        return PermissionHelper.hasPermission(
+            context,
+            Manifest.permission.READ_CONTACTS,
+            Manifest.permission.WRITE_CONTACTS,
+        )
+    }
+
+    private fun isLegacyAccountAFakeAccount(): Boolean {
+        return AccountManager.get(context).accounts.none {
+            it.name == DeviceAccountType.LEGACY_NAME
+                    && it.type == DeviceAccountType.LEGACY_TYPE
+        }
+    }
+
+    private fun clearLegacyAccountColumns() {
+        val values = ContentValues().apply {
+            putNull(RawContacts.ACCOUNT_NAME)
+            putNull(RawContacts.ACCOUNT_TYPE)
+        }
+
+        val selection =
+            "${RawContacts.ACCOUNT_NAME} = ? AND ${RawContacts.ACCOUNT_TYPE} = ?"
+        val selectionArgs =
+            arrayOf(DeviceAccountType.LEGACY_NAME, DeviceAccountType.LEGACY_TYPE)
+
+        contentResolver.update(
+            RawContacts.CONTENT_URI,
+            values,
+            selection,
+            selectionArgs
+        )
+        contentResolver.update(
+            ContactsContract.Groups.CONTENT_URI,
+            values,
+            selection,
+            selectionArgs
+        )
+    }
 
     companion object {
         const val MAX_PHOTO_SIZE = 700f

--- a/app/src/main/java/com/bnyro/contacts/presentation/features/FilterDialog.kt
+++ b/app/src/main/java/com/bnyro/contacts/presentation/features/FilterDialog.kt
@@ -37,8 +37,8 @@ fun FilterDialog(
         mutableStateOf(initialFilters.sortOrder)
     }
 
-    var hiddenAccountNames by remember {
-        mutableStateOf(initialFilters.hiddenAccountIdentifiers)
+    var hiddenAccounts by remember {
+        mutableStateOf(initialFilters.hiddenAccounts)
     }
 
     var visibleGroups by remember {
@@ -53,7 +53,7 @@ fun FilterDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
             DialogButton(text = stringResource(R.string.okay)) {
-                val options = FilterOptions(sortOrder, hiddenAccountNames, visibleGroups, favoritesOnly)
+                val options = FilterOptions(sortOrder, hiddenAccounts, visibleGroups, favoritesOnly)
                 onFilterChanged.invoke(options)
                 onDismissRequest.invoke()
             }
@@ -84,16 +84,16 @@ fun FilterDialog(
                     Spacer(modifier = Modifier.height(10.dp))
                     ChipSelector(
                         title = stringResource(R.string.account_type),
-                        entries = availableAccountTypes.map { it.type },
+                        entries = availableAccountTypes.map { it.displayType() },
                         selections = availableAccountTypes.filter {
-                            !hiddenAccountNames.contains(it.identifier)
-                        }.map { it.type },
+                            !hiddenAccounts.contains(it)
+                        }.map { it.displayType() },
                         onSelectionChanged = { index, newValue ->
                             val selection = availableAccountTypes[index]
-                            hiddenAccountNames = if (newValue) {
-                                hiddenAccountNames - selection.identifier
+                            hiddenAccounts = if (newValue) {
+                                hiddenAccounts - selection
                             } else {
-                                hiddenAccountNames + selection.identifier
+                                hiddenAccounts + selection
                             }
                         }
                     )

--- a/app/src/main/java/com/bnyro/contacts/presentation/screens/contact/SingleContactScreen.kt
+++ b/app/src/main/java/com/bnyro/contacts/presentation/screens/contact/SingleContactScreen.kt
@@ -273,7 +273,7 @@ fun SingleContactScreen(contact: ContactData, viewModel: ContactsModel, onClose:
             },
             isDeviceContact = (viewModel.contactsSource == ContactsSource.DEVICE),
             onSave = {
-                if (contact.accountIdentifier == it.accountIdentifier) {
+                if (contact.account == it.account) {
                     viewModel.updateContact(context, it)
                 } else {
                     viewModel.deleteContacts(listOf(it))

--- a/app/src/main/java/com/bnyro/contacts/presentation/screens/contacts/ContactsScreen.kt
+++ b/app/src/main/java/com/bnyro/contacts/presentation/screens/contacts/ContactsScreen.kt
@@ -370,7 +370,10 @@ fun ContactsPage(
             onFilterChanged = {
                 Preferences.edit {
                     putInt(Preferences.sortOrderKey, it.sortOrder.ordinal)
-                    putStringSet(Preferences.hiddenAccountsKey, it.hiddenAccountIdentifiers.toSet())
+                    putStringSet(
+                        Preferences.hiddenAccountsKey,
+                        it.hiddenAccounts.map { account -> account.toPreferencesString() }.toSet(),
+                    )
                     putBoolean(Preferences.favoritesOnlyKey, it.favoritesOnly)
                 }
                 filterOptions = it

--- a/app/src/main/java/com/bnyro/contacts/presentation/screens/contacts/model/ContactsModel.kt
+++ b/app/src/main/java/com/bnyro/contacts/presentation/screens/contacts/model/ContactsModel.kt
@@ -18,6 +18,7 @@ import com.bnyro.contacts.R
 import com.bnyro.contacts.domain.enums.ContactsSource
 import com.bnyro.contacts.domain.model.AccountType
 import com.bnyro.contacts.domain.model.ContactData
+import com.bnyro.contacts.domain.model.DeviceAccountType
 import com.bnyro.contacts.domain.model.FilterOptions
 import com.bnyro.contacts.domain.repositories.ContactsRepository
 import com.bnyro.contacts.domain.repositories.DeviceContactsRepository
@@ -207,7 +208,7 @@ class ContactsModel(
      */
     fun getAvailableAccounts(context: Context): List<AccountType> {
         if (!PermissionHelper.hasPermission(context, Manifest.permission.READ_SYNC_SETTINGS))
-            return listOf(AccountType.androidDefault)
+            return listOf(DeviceAccountType)
 
         return deviceContactsRepository.getAccountTypes()
     }
@@ -231,7 +232,7 @@ class ContactsModel(
 
     fun getContactsFilteredByOptions(filterOptions: FilterOptions): List<ContactData> {
         return contacts.filter {
-            !filterOptions.hiddenAccountIdentifiers.contains(it.accountIdentifier)
+            !filterOptions.hiddenAccounts.contains(it.account)
         }.filter {
             filterOptions.visibleGroups.isEmpty() || filterOptions.visibleGroups.any { group ->
                 it.groups.contains(group)

--- a/app/src/main/java/com/bnyro/contacts/presentation/screens/editor/components/ContactEditor.kt
+++ b/app/src/main/java/com/bnyro/contacts/presentation/screens/editor/components/ContactEditor.kt
@@ -64,7 +64,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bnyro.contacts.R
-import com.bnyro.contacts.domain.model.AccountType
 import com.bnyro.contacts.domain.model.ContactData
 import com.bnyro.contacts.domain.model.ValueWithType
 import com.bnyro.contacts.presentation.components.LabeledTextField
@@ -161,9 +160,7 @@ fun ContactEditor(
 
     var selectedAccount by remember {
         val lastChosenAccount = Preferences.getLastChosenAccount()
-        val account = contact?.let {
-            AccountType(it.accountName.orEmpty(), it.accountType.orEmpty())
-        } ?: lastChosenAccount
+        val account = contact?.account ?: lastChosenAccount
         mutableStateOf(account)
     }
 
@@ -193,8 +190,7 @@ fun ContactEditor(
                         it.title = title.value.takeIf { o -> o.isNotBlank() }?.trim()
                         it.displayName = "${firstName.value.trim()} ${surName.value.trim()}"
                         it.photo = profilePicture
-                        it.accountType = selectedAccount.type
-                        it.accountName = selectedAccount.name
+                        it.account = selectedAccount
                         it.websites = websites.clean()
                         it.numbers = phoneNumber.clean().map { number ->
                             number.copy(value = ContactsHelper.normalizePhoneNumber(number.value))
@@ -226,7 +222,9 @@ fun ContactEditor(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = selectedAccount.name.ifBlank { selectedAccount.type }
+                            text = selectedAccount.displayName().ifBlank {
+                                selectedAccount.displayType()
+                            }
                         )
                         Icon(
                             imageVector = Icons.Default.ArrowDropDown,
@@ -240,11 +238,11 @@ fun ContactEditor(
                     ) {
                         availableAccounts.forEach {
                             DropdownMenuItem(
-                                text = { Text(it.name) },
+                                text = { Text(it.displayName()) },
                                 onClick = {
                                     selectedAccount = it
                                     Preferences.edit {
-                                        putString(Preferences.lastChosenAccount, it.identifier)
+                                        putString(Preferences.lastChosenAccount, it.toPreferencesString())
                                     }
                                     expanded = false
                                 }

--- a/app/src/main/java/com/bnyro/contacts/util/Preferences.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/Preferences.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import com.bnyro.contacts.domain.enums.BackupType
 import com.bnyro.contacts.domain.model.AccountType
+import com.bnyro.contacts.domain.model.DeviceAccountType
 
 object Preferences {
     private const val prefFile = "preferences"
@@ -53,14 +54,9 @@ object Preferences {
     }
 
     fun getLastChosenAccount(): AccountType {
-        getString(lastChosenAccount, "")
-            .takeIf { !it.isNullOrBlank() }
-            ?.let {
-                val split = it.split("|")
-                return AccountType(split.last(), split.first())
-            }
-
-        return AccountType.androidDefault
+        return getString(lastChosenAccount, "")
+            ?.let { AccountType.fromPreferencesString(it) }
+            ?: DeviceAccountType
     }
 }
 

--- a/app/src/main/java/com/bnyro/contacts/util/Preferences.kt
+++ b/app/src/main/java/com/bnyro/contacts/util/Preferences.kt
@@ -35,6 +35,7 @@ object Preferences {
     const val biometricAuthKey = "biometricAuth"
     const val favoritesOnlyKey = "favoritesOnly"
     const val selectedSimSubscriptionIdKey = "selectedSimSubscriptionId"
+    const val legacyDeviceAccountsMigratedKey = "legacyDeviceAccountsMigrated"
 
     fun init(context: Context) {
         preferences = context.getSharedPreferences(prefFile, Context.MODE_PRIVATE)

--- a/app/src/test/java/com/bnyro/contacts/domain/model/AccountTypeTest.kt
+++ b/app/src/test/java/com/bnyro/contacts/domain/model/AccountTypeTest.kt
@@ -1,0 +1,85 @@
+package com.bnyro.contacts.domain.model
+
+import com.bnyro.contacts.domain.model.AccountType.Companion.fromAccountColumns
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class AccountTypeTest {
+
+    @Test
+    fun deviceAccountFromNullColumns() {
+        assertEquals(
+            DeviceAccountType,
+            fromAccountColumns(null, null)
+        )
+    }
+
+    @Test
+    fun deviceAccountFromLegacyAccount() {
+        assertEquals(
+            DeviceAccountType,
+            fromAccountColumns("DEVICE", "com.android.contacts")
+        )
+    }
+
+    @Test
+    fun realAccountFromRealColumns() {
+        assertEquals(
+            RealAccountType("someone@example.com", "example.com"),
+            fromAccountColumns("someone@example.com", "example.com")
+        )
+    }
+
+    @Test
+    fun deviceAccountToColumns() {
+        assertEquals(
+            AccountType.AccountColumns(null, null),
+            DeviceAccountType.toAccountColumns()
+        )
+    }
+
+    @Test
+    fun realAccountToColumns() {
+        assertEquals(
+            AccountType.AccountColumns("someone@example.com", "example.com"),
+            RealAccountType("someone@example.com", "example.com").toAccountColumns()
+        )
+    }
+
+    @Test
+    fun deviceAccountToPreferencesAndBack() {
+        assertEquals(
+            DeviceAccountType,
+            AccountType.fromPreferencesString(DeviceAccountType.toPreferencesString())
+        )
+    }
+
+    @Test
+    fun realAccountToPreferencesAndBack() {
+        val account = RealAccountType("someone@example.com", "example.com")
+        assertEquals(
+            account,
+            AccountType.fromPreferencesString(account.toPreferencesString())
+        )
+    }
+
+    @Test
+    fun accountFromInvalidPreferencesString() {
+        assertEquals(
+            null,
+            AccountType.fromPreferencesString("invalid.no.pipe.symbol")
+        )
+    }
+
+    @Test
+    fun accountFromLegacyPreferencesString() {
+        assertEquals(
+            DeviceAccountType,
+            AccountType.fromPreferencesString("com.android.contacts|DEVICE")
+        )
+    }
+
+}
+


### PR DESCRIPTION
The issue
-------------
Issue #477 and #275 both have contacts disappearing after some amount of delay.  This could readily be explained by the following: contacts made under the DEVICE account are saved using the dummy account values ("DEVICE", "com.android.contacts"); whenever an account is added or removed on the device, Android cleans up all contacts which have invalid (non-existing) accounts. So all contacts made in the app under DEVICE will be deleted.

The fix
---------

The fix comes in two commits:
1. change to representation of accounts in live memory - handles new DEVICE accounts
2. migration of all pre-existing contacts to the new format

Tested on emulator and my actual Samsung device (though the migration is a no-op on the Samsung).

Known limitations
-----------------------
At least one version of Samsung's Android has a bug where trying to set account_type and account_name to null just throws an exception.  In this case the migration gives up and doesn't run again.

Either we accept that the issue is fixed for all new contacts Samsung users create and we abandon the pre-existing ones to deletion, or we write some code to delete and then re-create the relevant contacts which is a more aggressive operation. I don't feel comfortable making the call on that.

Another concern is that, if there can be a bug in one OEM version of Android, then there could be another.  Perhaps we should wrap the whole function in a catch all to prevent a repeated crash-on-startup?

Notes
--------

This attempt at fixing the issue used no AI.
